### PR TITLE
removed entire event-stream package from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1247,18 +1247,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-      "requires": {
-        "duplexer": "0.1.1",
-        "pause-stream": "0.0.11",
-        "split": "1.0.1",
-        "stream-combiner": "0.2.2",
-        "through": "2.3.8"
-      }
-    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -6352,10 +6340,7 @@
     "ps-tree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "requires": {
-        "event-stream": "3.3.6"
-      }
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ="
     },
     "pseudomap": {
       "version": "1.0.2",


### PR DESCRIPTION
Due to message from GitHub that this package's latest version has critical vulnerabilities, the event-stream package was removed from the package-lock.json.  Per Github, if we need this package we need to use an earlier version.